### PR TITLE
Clarification on artifactory.repo argument

### DIFF
--- a/DockerMigrator.py
+++ b/DockerMigrator.py
@@ -48,7 +48,7 @@ def add_art_access(parser):
     art_group.add_argument('artifactory', help='The destination Artifactory URL')
     art_group.add_argument('username', help='The username to use for authentication to Artifactory')
     art_group.add_argument('password', help='The password to use for authentication to Artifactory')
-    art_group.add_argument('repo', help='The docker repository')
+    art_group.add_argument('repo', help='The docker repository in Artifactory to store the images')
 
 # Sets up the argument parser for the application
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ artifactory:
   artifactory           The destination Artifactory URL
   username              The username to use for authentication to Artifactory
   password              The password to use for authentication to Artifactory
-  repo                  The docker repository
+  repo                  The docker repository in Artifactory to store the images
 ```
 
 #### Importing from DockerHub
@@ -133,7 +133,7 @@ artifactory:
   artifactory           The destination Artifactory URL
   username              The username to use for authentication to Artifactory
   password              The password to use for authentication to Artifactory
-  repo                  The docker repository
+  repo                  The docker repository in Artifactory to store the images
 ```
 
 ### Quay Enterprise Edition registry migrator
@@ -184,7 +184,7 @@ artifactory:
   artifactory           The destination Artifactory URL
   username              The username to use for authentication to Artifactory
   password              The password to use for authentication to Artifactory
-  repo                  The docker repository
+  repo                  The docker repository in Artifactory to store the images
 
 ```
 
@@ -240,7 +240,7 @@ artifactory:
   artifactory           The destination Artifactory URL
   username              The username to use for authentication to Artifactory
   password              The password to use for authentication to Artifactory
-  repo                  The docker repository
+  repo                  The docker repository in Artifactory to store the images
 ```
 
 
@@ -281,7 +281,7 @@ artifactory:
   artifactory           The destination Artifactory URL
   username              The username to use for authentication to Artifactory
   password              The password to use for authentication to Artifactory
-  repo                  The docker repository
+  repo                  The docker repository in Artifactory to store the images
 ```
 
 ### Image file format
@@ -352,7 +352,7 @@ artifactory:
   artifactory        The destination Artifactory URL
   username           The username to use for authentication to Artifactory
   password           The password to use for authentication to Artifactory
-  repo               The docker repository
+  repo               The docker repository in Artifactory to store the images
 ```
 
 ### Quay EE Security Migration
@@ -400,7 +400,7 @@ artifactory:
   artifactory       The destination Artifactory URL
   username          The username to use for authentication to Artifactory
   password          The password to use for authentication to Artifactory
-  repo              The docker repository
+  repo              The docker repository in Artifactory to store the images
  ```
 
 


### PR DESCRIPTION
artifactory.repo is "The docker repository" which can be confusing when migrating from a docker registry. Clarification that the docker repository is in Artifactory.