### PR TITLE
Add params --source-project and --target-subfolder to enable project renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ usage: python DockerMigrator.py generic [-h]
                                         [--ignore-certs] [--overwrite]
                                         [--num-of-workers WORKERS] [-v]
                                         [--image-file IMAGE_FILE]
+                                        [--source-project HARBOR_SOURCE_PROJECT]
+                                        [--target-subfolder RT_TARGET_SUBFOLDER]
                                         source artifactory username password
                                         repo
 
@@ -74,6 +76,12 @@ optional arguments:
                         file. Format of new line separated file: '<image-
                         name>:<tag>' OR '<image-name>' to import all tags of
                         that repository.
+  --source-project HARBOR_SOURCE_PROJECT_TO_BE_TRIMMED_OR_REPLACED
+                        Checks each images in --image-file; trims the image prefix that has the same 
+                        name with --source-project. Only works together with --image-file
+  --target-subfolder RT_TARGET_SUBFOLDER
+                        Add a subfolder as a prefix to the images in --image-file. 
+                        Only works together with --image-file and --source-project
 
 source:
   source                The source registry URL


### PR DESCRIPTION
Hi, this is the commit that answers the issue #20 
I've added two extra parameters to enable trimming/replacing of project name of original harbor images. They all need to work together with --image-file:

1. --source-project HARBOR_SOURCE_PROJECT. Checks each images in --image-file; trims the image prefix that has the same name with --source-project. Only works together with --image-file.

2. --target-subfolder RT_TARGET_SUBFOLDER. Add a subfolder as a prefix to the images in --image-file. Only works together with --image-file and --source-project.

Besides that, I've also added a cli output of the image name so people can be more aware of the progress of the migration. I hope this helps more people like me.